### PR TITLE
Different Nokogiri methods on HTML nodes deal differently with encodi…

### DIFF
--- a/lib/include/preprocess.rb
+++ b/lib/include/preprocess.rb
@@ -6,6 +6,7 @@ class PandocPreprocess
   def initialize(html)
     @source = html
     @doc = Nokogiri::HTML(html)
+    doc.encoding = 'UTF-8'
     @downloads = {}
   end
 

--- a/lib/include/preprocess.rb
+++ b/lib/include/preprocess.rb
@@ -55,7 +55,7 @@ class PandocPreprocess
     # TODO: ensure neither title or subtitle occur more than once, or are empty
     %w[title subtitle].each do |type|
       doc.css("p.#{type}").each do |x|
-        x.replace("<h1 class='ew-pandoc-#{type}'>#{x.text}</h1>")
+        x.replace("<h1 class='ew-pandoc-#{type}'>#{x.inner_html}</h1>")
       end
     end
   end

--- a/lib/include/preprocess.rb
+++ b/lib/include/preprocess.rb
@@ -55,7 +55,7 @@ class PandocPreprocess
     # TODO: ensure neither title or subtitle occur more than once, or are empty
     %w[title subtitle].each do |type|
       doc.css("p.#{type}").each do |x|
-        x.replace("<h1 class='ew-pandoc-#{type}'>#{x.inner_html}</h1>")
+        x.replace("<h1 class='ew-pandoc-#{type}'>#{x.text}</h1>")
       end
     end
   end

--- a/lib/pandoc-preprocess.rb
+++ b/lib/pandoc-preprocess.rb
@@ -6,4 +6,4 @@ html = ARGF.read
 preproc = PandocPreprocess.new(html)
 preproc.process
 preproc.download_resources
-puts preproc.doc.to_html
+puts preproc.doc.to_html(encoding: 'ASCII')


### PR DESCRIPTION
…ng. "x.text" couldn't handle diacritics which was problematic for dealing with French text.



This fixes the bug related to handling accented French letters in titles and sub-titles.