### PR TITLE
 Making it so pandoc respects the dimensions of images in gdocs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  ubuntu:trusty
+FROM  ubuntu:bionic
 MAINTAINER Alex Dergachev <alex@evolvingweb.ca>
 
 # check if the docker host is running squid-deb-proxy, and use it
@@ -9,14 +9,15 @@ RUN echo "HEAD /" | nc `cat /tmp/host_ip.txt` 8000 | grep squid-deb-proxy && (ec
 RUN apt-get update -y && apt-get install -y curl wget git fontconfig make vim
 
 RUN echo 'LC_ALL="en_US.UTF-8"' > /etc/default/locale
-RUN apt-get install -y ruby1.9.3
+RUN apt-get install -y ruby2.5
 
 # get pandocfilters, a helper library for writing pandoc filters in python
 RUN apt-get -y install python-pip
 RUN pip install pandocfilters
 
 # latex tools
-RUN apt-get update -y && apt-get install -y texlive-latex-base texlive-xetex latex-xcolor texlive-math-extra texlive-latex-extra texlive-fonts-extra rubber latexdiff
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y && apt-get install -y apt-utils && apt-get install -y texlive-latex-base texlive-xetex texlive-pstricks texlive-science texlive-latex-extra texlive-fonts-extra rubber latexdiff
 
 # greatly speeds up nokogiri install
 # dependencies for nokogiri gem
@@ -28,7 +29,8 @@ RUN (gem list bundler | grep bundler) || gem install bundler
 # install gems
 ADD Gemfile /tmp/
 ADD Gemfile.lock /tmp/
-RUN cd /tmp && bundle config build.nokogiri --use-system-libraries && bundle install
+RUN apt-get install -y build-essential patch ruby-dev zlib1g-dev liblzma-dev
+RUN cd /tmp && bundle config build.nokogiri --use-system-libraries --with-xml2-include=/usr/include/libxml2 --with-xml2-lib=/usr/lib/ && bundle install
 
 # install pandoc 1.12 by from manually downloaded trusty deb packages (saucy only has 1.11, which is too old)
 #RUN apt-get install -y pandoc

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,10 @@ ADD Gemfile.lock /tmp/
 RUN cd /tmp && bundle config build.nokogiri --use-system-libraries && bundle install
 
 # install pandoc 1.12 by from manually downloaded trusty deb packages (saucy only has 1.11, which is too old)
-RUN apt-get install -y pandoc
+#RUN apt-get install -y pandoc
+RUN mkdir -p /tmp/debs/ && cd /tmp/debs && \
+    wget https://github.com/jgm/pandoc/releases/download/2.2.3.2/pandoc-2.2.3.2-1-amd64.deb && \
+    dpkg -i *.deb
 
 EXPOSE 12736
 WORKDIR /var/gdocs-export/

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,5 @@ gem "nokogiri"
 
 gem "rspec", ">=3.1"
 gem "rspec_junit_formatter", :group => :development
+
+gem "css_parser", "~> 1.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,8 @@ GEM
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
     builder (3.2.2)
+    css_parser (1.6.0)
+      addressable
     diff-lcs (1.2.5)
     extlib (0.9.16)
     faraday (0.8.11)
@@ -25,11 +27,13 @@ GEM
       multi_json (>= 1.5)
     launchy (2.4.3)
       addressable (~> 2.3)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.3.0)
     multi_json (1.11.2)
     multipart-post (1.2.0)
-    nokogiri (1.6.7.1)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.8.4)
+      mini_portile2 (~> 2.3.0)
+    nokogiri (1.8.4-x64-mingw32)
+      mini_portile2 (~> 2.3.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -56,8 +60,10 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
+  css_parser (~> 1.6)
   google-api-client (= 0.6.4)
   jwt (~> 0.1.4)
   nokogiri
@@ -66,4 +72,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.15.4
+   1.16.3

--- a/Makefile
+++ b/Makefile
@@ -48,12 +48,12 @@ latex:
 	cp $(input_file) $(OUTPUT)/in.html
 
 	bundle exec ruby -C$(OUTPUT) "$$PWD/lib/pandoc-preprocess.rb" in.html > $(OUTPUT)/preprocessed.html
-	pandoc --parse-raw $(OUTPUT)/preprocessed.html -t json > $(OUTPUT)/pre.json
+	pandoc $(OUTPUT)/preprocessed.html -f html+raw_html -t json > $(OUTPUT)/pre.json
 	cat $(OUTPUT)/pre.json | ./lib/pandoc-filter.py > $(OUTPUT)/post.json
 
 	# use pandoc to create metadata.tex, main.tex (these are included by ew-template.tex)
-	pandoc $(OUTPUT)/post.json --no-wrap -t latex --template $(OUTPUT)/template-metadata.tex > $(OUTPUT)/metadata.tex
-	pandoc $(OUTPUT)/post.json --chapters --no-wrap -t latex > $(OUTPUT)/main.tex
+	pandoc $(OUTPUT)/post.json --wrap=none -t latex --template $(OUTPUT)/template-metadata.tex > $(OUTPUT)/metadata.tex
+	pandoc $(OUTPUT)/post.json --top-level-division=chapter --wrap=none -t latex > $(OUTPUT)/main.tex
 
 	# must use -o with docx output format, since its binary
 	pandoc $(OUTPUT)/post.json -s -t docx -o $(OUTPUT)/$(name).docx
@@ -64,13 +64,13 @@ pdf:
 	echo "Created $(OUTPUT)/$(name).tex, compiling into $(name).pdf"
 	# rubber will set output PDF filename based on latex input filename
 	cp -f $(OUTPUT)/template.tex $(OUTPUT)/$(name).tex
-	( cd $(OUTPUT); latexmk -pdf $(name))
+	( cd $(OUTPUT); rubber --pdf $(name))
 
 convert: latex pdf
 
 diff:
 	/usr/bin/perl "`which latexdiff`" --flatten $(outdir)/$(before)/$(before).tex $(OUTPUT)/$(name).tex > $(OUTPUT)/diff.tex
-	(cd $(OUTPUT); latexmk -pdf diff)
+	(cd $(OUTPUT); rubber --pdf diff)
 
 
 #===============================================================================

--- a/assets/default/template.tex
+++ b/assets/default/template.tex
@@ -69,7 +69,8 @@
 \else\Gin@nat@width\fi}
 \makeatother
 \let\Oldincludegraphics\includegraphics
-\renewcommand{\includegraphics}[1]{\Oldincludegraphics[width=\maxwidth]{#1}}
+% The line below breaks the way that pandoc converts image metadata in unexpected ways.
+%\renewcommand{\includegraphics}[1]{\Oldincludegraphics[width=\maxwidth]{#1}}
 
 % Uncomment to make embedded links print out HREF in footnotes, good for printing
 % \renewcommand{\href}[2]{#2\footnote{\url{#1}}}

--- a/lib/include/preprocess.rb
+++ b/lib/include/preprocess.rb
@@ -30,6 +30,7 @@ class PandocPreprocess
     fixup_empty_headers
     fixup_page_breaks
     fixup_lists
+    fixup_image_attributes
   end
 
   # Replace remote with local images
@@ -179,6 +180,16 @@ class PandocPreprocess
       found = true
       short = e.text[0, 30]
       @errors << "Colspan > 1 for \"#{short}\""
+    end
+  end
+  # Add width and height attributes to images.
+  def fixup_image_attributes
+    doc.css("img").each do |img|
+      style = img.attr('style')
+      %w[height width].each do |att|
+        val = style.match(/#{att}\s*:\s*([\d.]+)px/)[1]
+        img.set_attribute(att, val)
+      end
     end
   end
 end


### PR DESCRIPTION
Lacking feature in the gdocs-export program that has been requested.

Depends on this previous pull request: https://github.com/dergachev/gdocs-export/pull/14